### PR TITLE
fix: package name is incorrect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextauth-sample-app",
+  "name": "sample-nextauth-to-keycloak",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## 概要

タイトル通り。
org 内部向けに展開していたタイミングから、名称が変わっているため、lock ファイルの方も変更されているべきだった